### PR TITLE
refactor: use extendBuild API instead of custom chaining

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -1,14 +1,7 @@
 const logger = require('consola').withScope('nuxt-svg-loader')
 
 export default function nuxtSvgLoader() {
-  const oldExtendFunction = this.options.build.extend
-
-  this.options.build.extend = (...args) => {
-    setupVueSvgLoader(...args)
-    if (oldExtendFunction) {
-      oldExtendFunction(...args)
-    }
-  }
+  this.extendBuild(setupVueSvgLoader)
 }
 
 const setupVueSvgLoader = (config) => {

--- a/test/fixture/modules/error.js
+++ b/test/fixture/modules/error.js
@@ -1,11 +1,6 @@
 module.exports = function () {
-  const oldExtendFunction = this.options.build.extend
-
-  this.options.build.extend = (config, options) => {
+  this.extendBuild((config, options) => {
     const imageLoaderRule = config.module.rules.find(rule => rule.test && /svg/.test(rule.test.toString()))
     imageLoaderRule.test = /^$/
-    if (oldExtendFunction) {
-      oldExtendFunction(config, options)
-    }
-  }
+  })
 }


### PR DESCRIPTION
We all know these moments where we build our own workaround though there is an "official" way through the API :see_no_evil: 

resolves #9 