### PR TITLE
doc(readme): add information for typescript user

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,19 @@ export default {
 
 - No more options are needed. It'll simply work
 
+### TypeScript Specificities
+
+When using Nuxt with TypeScript you need to add custom typing to help the TypeScript Engine to know what is the `svg` extension.
+
+```ts
+// file: types.d.ts
+
+declare module '*.svg' {
+  const content: any
+  export default content
+}
+```
+
 ## Configuration
 
 The plugin will work seamlessly out of the box.


### PR DESCRIPTION
Hey 👋 

When using this package with TypeScript the engine doesn't know by default how to deal with `svg` file. Therefore we need to defer the type for these imports.

More information: https://webpack.js.org/guides/typescript/#importing-other-assets