### PR TITLE
docs: fix regex for eslint

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ build: {
         enforce: 'pre',
         test: /\.(js|vue)$/,
         loader: 'eslint-loader',
-        exclude: /(node_modules)||(.svg$)/ /* <--- here */
+        exclude: /(node_modules)|(\.svg$)/ /* <--- here */
       })
     }
   }


### PR DESCRIPTION
The regex in the README matches _all_ file paths (due to the empty space between `||`).